### PR TITLE
Restore correct struct name from smoke-aws.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "cdeffe8c5bb88288ee624bb81fefe0508abe5a29",
-          "version": "2.43.0"
+          "revision": "bc4c55b9f9584f09eb971d67d956e28d08caa9d0",
+          "version": "2.43.1"
         }
       },
       {

--- a/Sources/AWSHttp/SmokeAWSHTTPClientInvocationReporting.swift
+++ b/Sources/AWSHttp/SmokeAWSHTTPClientInvocationReporting.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  AWSHttpClientInvocationReporting.swift
+//  SmokeAWSHTTPClientInvocationReporting.swift
 //  AWSHttp
 //
 
@@ -22,7 +22,7 @@ import NIO
 import Logging
 import Metrics
 
-public struct AWSHttpClientInvocationReporting<InvocationReportingType: HTTPClientCoreInvocationReporting>: HTTPClientInvocationReporting {
+public struct SmokeAWSHTTPClientInvocationReporting<InvocationReportingType: HTTPClientCoreInvocationReporting>: HTTPClientInvocationReporting {
     public typealias TraceContextType = InvocationReportingType.TraceContextType
     
     private let smokeAWSInvocationReporting: InvocationReportingType


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Restore correct struct name from smoke-aws.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
