### PR TITLE
Add CloudwatchJsonStandardErrorLoggerV2

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,11 +11,11 @@ jobs:
     name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
-        swift: ["5.7"]
+        os: [ubuntu-22.04, ubuntu-20.04]
+        swift: ["5.7.2"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.18.0
+      - uses: swift-actions/setup-swift@v1.21.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
         swift: ["5.6.3", "5.5.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.18.0
+      - uses: swift-actions/setup-swift@v1.21.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
+++ b/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
@@ -18,8 +18,6 @@
 import Foundation
 import Logging
 
-#if compiler(>=5.7)
-
 private let sourcesSubString = "Sources/"
 
 private struct LogEntry: Encodable {
@@ -76,7 +74,7 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
         var newEntryQueueFinishHandler: (() -> ())?
         // create an async stream with a handler for adding new elments
         // and a handler for finishing the stream
-        let rawEntryStream = AsyncStream { continuation in
+        let rawEntryStream = AsyncStream<String> { continuation in
             newEntryHandler = { entry in
                 continuation.yield(entry)
             }
@@ -188,4 +186,3 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
         }
     }
 }
-#endif

--- a/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
+++ b/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
@@ -55,7 +55,7 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
     
     private let entryStream: AsyncStream<String>
     private let stream: TextOutputStream
-    private let entryHander: (String) -> ()
+    private let entryHandler: (String) -> ()
     private let entryQueueFinishHandler: () -> ()
     private let metadataTypes: [String: MetadataType]
     
@@ -72,7 +72,7 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
         
         var newEntryHandler: ((String) -> ())?
         var newEntryQueueFinishHandler: (() -> ())?
-        // create an async stream with a handler for adding new elments
+        // create an async stream with a handler for adding new elements
         // and a handler for finishing the stream
         let rawEntryStream = AsyncStream<String> { continuation in
             newEntryHandler = { entry in
@@ -89,7 +89,7 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
         }
         
         self.entryStream = rawEntryStream
-        self.entryHander = newEntryHandler
+        self.entryHandler = newEntryHandler
         self.entryQueueFinishHandler = newEntryQueueFinishHandler
         self.stream = NonLockingStdioOutputStream.stderr
     }
@@ -103,6 +103,7 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
     // is called.
     public func run() async {
         for await jsonMessage in self.entryStream {
+            // get a mutable version of the stream
             var stream = self.stream
             stream.write("\(jsonMessage)\n")
         }
@@ -181,7 +182,7 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
             if let jsonData = try? self.jsonEncoder.encode(logEntry),
                let jsonMessage = String(data: jsonData, encoding: .utf8) {
                 // pass to the entry queue
-                self.entryHander(jsonMessage)
+                self.entryHandler(jsonMessage)
             }
         }
     }

--- a/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
+++ b/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
@@ -1,0 +1,176 @@
+//
+//  CloudWatchPendingMetricsQueueV2.swift
+//  SmokeExtras
+//
+
+import Foundation
+import Logging
+
+private let sourcesSubString = "Sources/"
+
+private struct LogEntry: Encodable {
+    let stringFields: [String: String]
+    let integerFields: [String: Int]
+    
+    func encode(to encoder: Encoder) throws {
+        try self.stringFields.encode(to: encoder)
+        try self.integerFields.encode(to: encoder)
+    }
+}
+
+public enum MetadataType {
+    case String
+    case Int
+}
+
+/**
+ Implementation of the Logger protocol that emits logs as
+ required to Standard error to be picked up by Cloudwatch logs.
+ 
+ Serialises the JSON payload of each log line on DispatchQueue.global()
+ before submitting each to an AsyncSequence. This sequence is consumed
+ in the `run()` function, resulting in a non-blocking implementation.
+ 
+ Named metadata entries can be specified as a particular `MetadataType` and they will
+ be emitted in the JSON structure appropriately. Unspecified metadata entries will be emitted as
+ strings.
+ */
+public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
+    public var metadata: Logger.Metadata
+    public var logLevel: Logger.Level
+    
+    private let jsonEncoder: JSONEncoder
+    
+    private let entryStream: AsyncStream<String>
+    private let stream: TextOutputStream
+    private let entryHander: (String) -> ()
+    private let entryQueueFinishHandler: () -> ()
+    private let metadataTypes: [String: MetadataType]
+    
+    private init(minimumLogLevel: Logger.Level,
+                 metadataTypes: [String: MetadataType]) {
+        self.logLevel = minimumLogLevel
+        self.metadata = [:]
+        self.metadataTypes = metadataTypes
+        
+        let theJsonEncoder = JSONEncoder()
+        theJsonEncoder.outputFormatting = [.sortedKeys]
+        
+        self.jsonEncoder = theJsonEncoder
+        
+        var newEntryHandler: ((String) -> ())?
+        var newEntryQueueFinishHandler: (() -> ())?
+        // create an async stream with a handler for adding new elments
+        // and a handler for finishing the stream
+        let rawEntryStream = AsyncStream { continuation in
+            newEntryHandler = { entry in
+                continuation.yield(entry)
+            }
+            
+            newEntryQueueFinishHandler = {
+                continuation.finish()
+            }
+        }
+        
+        guard let newEntryHandler = newEntryHandler, let newEntryQueueFinishHandler = newEntryQueueFinishHandler else {
+            fatalError()
+        }
+        
+        self.entryStream = rawEntryStream
+        self.entryHander = newEntryHandler
+        self.entryQueueFinishHandler = newEntryQueueFinishHandler
+        self.stream = NonLockingStdioOutputStream.stderr
+    }
+    
+    public func shutdown() {
+        self.entryQueueFinishHandler()
+    }
+    
+    // Consume the log entries from the entryStream.
+    // This function will not return until after `shutdown()`
+    // is called.
+    public func run() async {
+        for await jsonMessage in self.entryStream {
+            var stream = self.stream
+            stream.write("\(jsonMessage)\n")
+        }
+    }
+    
+    public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+        get {
+            return metadata[metadataKey]
+        }
+        set {
+            metadata[metadataKey] = newValue
+        }
+    }
+    
+    /**
+     Set the logger implementation of the LoggerAPI to this type.
+     */
+    public static func enableLogging(minimumLogLevel: Logger.Level = .info,
+                                     metadataTypes: [String: MetadataType] = [:]) -> CloudwatchJsonStandardErrorLoggerV2 {
+        let logger = CloudwatchJsonStandardErrorLoggerV2(minimumLogLevel: minimumLogLevel, metadataTypes: metadataTypes)
+        
+        LoggingSystem.bootstrap { label in
+            return logger
+        }
+        
+        return logger
+    }
+    
+    public func log(level: Logger.Level, message: Logger.Message,
+                    metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
+        let shortFileName: String
+        if let range = file.range(of: "Sources/") {
+            let startIndex = file.index(range.lowerBound, offsetBy: sourcesSubString.count)
+            shortFileName = String(file[startIndex...])
+        } else {
+            shortFileName = file
+        }
+        
+        let metadataToUse: Logger.Metadata
+        if let metadata = metadata {
+            metadataToUse = self.metadata.merging(metadata) { (global, local) in local }
+        } else {
+            metadataToUse = self.metadata
+        }
+        
+        var codableMetadata: [String: String] = [:]
+        var codableMetadataInts: [String: Int] = [:]
+        metadataToUse.forEach { (key, value) in
+            // determine the metadata type
+            let metadataType: MetadataType
+            if let theMetadataType = self.metadataTypes[key] {
+                metadataType = theMetadataType
+            } else {
+                metadataType = .String
+            }
+            
+            // add to the appropriate dictionary, converting if necessary
+            switch metadataType {
+            case .String:
+                codableMetadata[key] = value.description
+            case .Int:
+                codableMetadataInts[key] = Int(value.description)
+            }
+        }
+        
+        codableMetadata["fileName"] = shortFileName
+        codableMetadataInts["line"] = Int(line)
+        codableMetadata["function"] = function
+        codableMetadata["level"] = level.rawValue
+        codableMetadata["message"] = "\(message)"
+        
+        // pass to the global dispatch queue for serialization
+        // schedule at a low priority to avoid disrupting request handling
+        DispatchQueue.global().async(qos: .utility) {
+            let logEntry = LogEntry(stringFields: codableMetadata, integerFields: codableMetadataInts)
+            if let jsonData = try? self.jsonEncoder.encode(logEntry),
+               let jsonMessage = String(data: jsonData, encoding: .utf8) {
+                // pass to the entry queue
+                self.entryHander(jsonMessage)
+            }
+        }
+    }
+}

--- a/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
+++ b/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-// CloudWatchPendingMetricsQueueV2.swift
+// CloudwatchJsonStandardErrorLoggerV2.swift
 // AWSLogging
 //
 

--- a/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
+++ b/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
@@ -1,6 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
-//  CloudWatchPendingMetricsQueueV2.swift
-//  SmokeExtras
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// CloudWatchPendingMetricsQueueV2.swift
+// AWSLogging
 //
 
 import Foundation

--- a/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
+++ b/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
@@ -18,6 +18,8 @@
 import Foundation
 import Logging
 
+#if compiler(>=5.7)
+
 private let sourcesSubString = "Sources/"
 
 private struct LogEntry: Encodable {
@@ -186,3 +188,4 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
         }
     }
 }
+#endif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adds a `LogHandler` implementation for Cloudwatch logs that-
1. serialises off the request thread
2. uses an AsyncSequence to be non-blocking
3. Provides the ability to specify named metadata entries as particular JSON types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
