### PR TITLE
Logging serialization queue

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,7 +29,7 @@ jobs:
         swift: ["5.6.3", "5.5.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.21.0
+      - uses: swift-actions/setup-swift@v1.22.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        swift: ["5.7.2"]
+        swift: ["5.7.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.21.0
+      - uses: swift-actions/setup-swift@v1.22.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
+++ b/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
@@ -52,6 +52,9 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
     public var logLevel: Logger.Level
     
     private let jsonEncoder: JSONEncoder
+    private let serializationQueue = DispatchQueue(
+                label: "com.amazon.SmokeAwsSupport.CloudwatchJsonStandardErrorLoggerV2.serializationQueue",
+                target: DispatchQueue.global())
     
     private let entryStream: AsyncStream<String>
     private let stream: TextOutputStream
@@ -177,7 +180,7 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
         
         // pass to the global dispatch queue for serialization
         // schedule at a low priority to avoid disrupting request handling
-        DispatchQueue.global().async(qos: .utility) {
+        self.serializationQueue.async(qos: .utility) {
             let logEntry = LogEntry(stringFields: codableMetadata, integerFields: codableMetadataInts)
             if let jsonData = try? self.jsonEncoder.encode(logEntry),
                let jsonMessage = String(data: jsonData, encoding: .utf8) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use a serial DispatchQueue for log message serialization. This avoid the potential for thread-explosion when too many log messages are created. The only potential negative impact of this change would be contention on this serial queue and not keeping up with emitting log messages. Testing under load has not seen this occur.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
