### PR TITLE
Metadata provider support for CloudwatchJsonStandardErrorLoggerV2.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: swift build -c release
-      - name: Run tests
-        run: swift test
   OlderVersionBuild:
     name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
     strategy:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,24 +12,26 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        swift: ["5.7.3"]
+        swift: ["5.8"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.22.0
+      - uses: swift-actions/setup-swift@v1.23.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
       - name: Build
         run: swift build -c release
+      - name: Run tests
+        run: swift test
   OlderVersionBuild:
     name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.6.3", "5.5.3"]
+        swift: ["5.7.3", "5.6.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.22.0
+      - uses: swift-actions/setup-swift@v1.23.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-aws-support/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.5|5.6|5.7-orange.svg?style=flat" alt="Swift 5.5, 5.6 and 5.7 Tested">
+<img src="https://img.shields.io/badge/swift-5.6|5.7|5.8-orange.svg?style=flat" alt="Swift 5.6, 5.7 and 5.8 Tested">
 </a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">

--- a/Sources/AWSHttp/FormEncodedXMLAWSHttpClientDelegate.swift
+++ b/Sources/AWSHttp/FormEncodedXMLAWSHttpClientDelegate.swift
@@ -25,6 +25,7 @@ import QueryCoding
 import HTTPHeadersCoding
 import HTTPPathCoding
 import AsyncHTTPClient
+import ShapeCoding
 
 /**
  Struct conforming to the AWSHttpClientDelegate protocol that encodes request query items into the body and

--- a/Sources/AWSHttp/XMLAWSHttpClientDelegate.swift
+++ b/Sources/AWSHttp/XMLAWSHttpClientDelegate.swift
@@ -26,6 +26,7 @@ import QueryCoding
 import HTTPHeadersCoding
 import HTTPPathCoding
 import AsyncHTTPClient
+import ShapeCoding
 
 extension CharacterSet {
     public static let uriAWSQueryValueAllowed: CharacterSet = ["~", "-", ".", "0", "1", "2", "3", "4",

--- a/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
+++ b/Sources/AWSLogging/CloudwatchJsonStandardErrorLoggerV2.swift
@@ -145,7 +145,7 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
     }
     
     public func log(level: Logger.Level, message: Logger.Message,
-                    metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
+                    metadata explicit: Logger.Metadata?, file: String, function: String, line: UInt) {
         let shortFileName: String
         if let range = file.range(of: "Sources/") {
             let startIndex = file.index(range.lowerBound, offsetBy: sourcesSubString.count)
@@ -157,11 +157,11 @@ public struct CloudwatchJsonStandardErrorLoggerV2: LogHandler {
         var metadataToUse: Logger.Metadata = self.metadata
                 
         if let provided = self.metadataProvider?.get() {
-            metadataToUse = metadataToUse.merging(provided) { (global, local) in local }
+            metadataToUse.merge(provided) { _, provided in provided }
         }
         
-        if let metadata = metadata {
-            metadataToUse = metadataToUse.merging(metadata) { (global, local) in local }
+        if let explicit = explicit {
+            metadataToUse.merge(explicit) { _, explicit in explicit }
         }
         
         var codableMetadata: [String: String] = [:]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add support for [Metadata Providers](https://github.com/apple/swift-log/pull/238) to CloudwatchJsonStandardErrorLoggerV2. A Metadata Provider is another source of metadata for a log event. Provides the ability to provide a global metadata provider through the `CloudwatchJsonStandardErrorLoggerV2.enableLogging` function. This function passes the provider to `LoggingSystem.bootstrap`  as the default provider while providing a logHandler factory that returns a log handler with the provider passed to the factory method (this may not be the default provider if it has been overridden when a Logger is created).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
