### PR TITLE
Correctly encode query string when path already contains query parame…

### DIFF
--- a/Sources/AWSHttp/DataAWSHttpClientDelegate.swift
+++ b/Sources/AWSHttp/DataAWSHttpClientDelegate.swift
@@ -128,7 +128,8 @@ public struct DataAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
                                                            allowedCharacterSet: .uriAWSQueryValueAllowed)
                 
                 if !encodedQuery.isEmpty {
-                    query = "?" + encodedQuery
+                    let separator = path.contains("?") ? "&" : "?"
+                    query = separator + encodedQuery
                 } else {
                     query = ""
                 }

--- a/Sources/AWSHttp/JSONAWSHttpClientDelegate.swift
+++ b/Sources/AWSHttp/JSONAWSHttpClientDelegate.swift
@@ -120,7 +120,8 @@ public struct JSONAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClien
                                                            allowedCharacterSet: .uriAWSQueryValueAllowed)
                 
                 if !encodedQuery.isEmpty {
-                    query = "?" + encodedQuery
+                    let separator = path.contains("?") ? "&" : "?"
+                    query = separator + encodedQuery
                 } else {
                     query = ""
                 }

--- a/Sources/AWSHttp/XMLAWSHttpClientDelegate.swift
+++ b/Sources/AWSHttp/XMLAWSHttpClientDelegate.swift
@@ -222,7 +222,8 @@ public struct XMLAWSHttpClientDelegate<ErrorType: Error & Decodable>: HTTPClient
                                                            allowedCharacterSet: .uriAWSQueryValueAllowed)
 
                 if !encodedQuery.isEmpty {
-                    query = "?" + encodedQuery
+                    let separator = path.contains("?") ? "&" : "?"
+                    query = separator + encodedQuery
                 } else {
                     query = ""
                 }


### PR DESCRIPTION
…ters

*Issue #, if available:*

*Description of changes:*
There was an issue with the encoding of the query parameters in the path. When the `httpPath` already contained query parameters, more than one question mark would be added to the path.

For example, if `httpPath` is `/somePath?par1=val1`, the URL would be encoded as `https://mydomain.com/somePath?par1=val1?par2=val2&par3=val3`, which is invalid.

With the change, the URL will correctly be encoded as `https://mydomain.com/somePath?par1=val1&par2=val2&par3=val3`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
