### PR TITLE
Sort query parameters alphabetically in V4 signer

### DIFF
--- a/Sources/AWSHttp/V4Signer.swift
+++ b/Sources/AWSHttp/V4Signer.swift
@@ -233,14 +233,20 @@ struct V4Signer {
         if let rawQuery = url.query {
             let queryComponents = rawQuery.split(separator: "&")
             
-            let mappedComponents: [String] = queryComponents.map { component in
-                if component.firstIndex(of: "=") == nil {
+            let mappedComponents: [String] = queryComponents.map { component -> (key: String, component: String) in
+                let parameterComponents = component.split(separator: "=")
+                let key = parameterComponents[0]
+
+                let formattedComponent: String
+                if parameterComponents.count == 1 {
                     // query keys without values require '=' at the end
-                    return "\(component)="
+                    formattedComponent = "\(component)="
                 } else {
-                    return String(component)
+                    formattedComponent = String(component)
                 }
-            }
+
+                return (String(key), formattedComponent)
+            }.sorted(by: { $0.key < $1.key }).map(\.component)
             
             query = mappedComponents.joined(separator: "&")
         } else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As described in https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html, when building the CanonicalQueryString to get the string to sign and send with the AWS request, the query parameters need to be sorted alphabetically by key. Previously, they were not sorted.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
