### PR TITLE
Just unwrap the HTTPServerError.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "864c8d9e0ead5de7ba70b61c8982f89126710863",
-          "version": "1.15.0"
+          "revision": "78db67e5bf4a8543075787f228e8920097319281",
+          "version": "1.18.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "355e538ba26536ef8f3040bf55af7b1282a685c0",
-          "version": "2.18.0"
+          "revision": "84e6805ca07f9e4d7c39fbf61b7feff0484ee67f",
+          "version": "2.21.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
           "branch": null,
-          "revision": "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
-          "version": "1.0.3"
+          "revision": "6c89474e62719ddcc1e9614989fff2f68208fe10",
+          "version": "1.1.0"
         }
       },
       {
@@ -47,12 +47,21 @@
         }
       },
       {
+        "package": "swift-distributed-tracing",
+        "repositoryURL": "https://github.com/apple/swift-distributed-tracing.git",
+        "state": {
+          "branch": null,
+          "revision": "49b7617717a09f6b781c9a11e1628e3315d8d4fe",
+          "version": "1.0.1"
+        }
+      },
+      {
         "package": "swift-log",
         "repositoryURL": "https://github.com/apple/swift-log",
         "state": {
           "branch": null,
-          "revision": "32e8d724467f8fe623624570367e3d50c5638e46",
-          "version": "1.5.2"
+          "revision": "532d8b529501fb73a2455b179e0bbb6d49b652ed",
+          "version": "1.5.3"
         }
       },
       {
@@ -60,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "e8bced74bc6d747745935e469f45d03f048d6cbd",
-          "version": "2.3.4"
+          "revision": "971ba26378ab69c43737ee7ba967a896cb74c0d1",
+          "version": "2.4.1"
         }
       },
       {
@@ -69,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "45167b8006448c79dda4b7bd604e07a034c15c49",
-          "version": "2.48.0"
+          "revision": "cf281631ff10ec6111f2761052aa81896a83a007",
+          "version": "2.58.0"
         }
       },
       {
@@ -78,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "d75ed708d00353acf173ca23018b6bd46f949464",
-          "version": "1.17.0"
+          "revision": "0e0d0aab665ff1a0659ce75ac003081f2b1c8997",
+          "version": "1.19.0"
         }
       },
       {
@@ -87,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "38feec96bcd929028939107684073554bf01abeb",
-          "version": "1.25.2"
+          "revision": "a8ccf13fa62775277a5d56844878c828bbb3be1a",
+          "version": "1.27.0"
         }
       },
       {
@@ -96,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "4fb7ead803e38949eb1d6fabb849206a72c580f3",
-          "version": "2.23.0"
+          "revision": "e866a626e105042a6a72a870c88b4c531ba05f83",
+          "version": "2.24.0"
         }
       },
       {
@@ -105,8 +114,17 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "c0d9a144cfaec8d3d596aadde3039286a266c15c",
-          "version": "1.15.0"
+          "revision": "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
+          "version": "1.19.0"
+        }
+      },
+      {
+        "package": "swift-service-context",
+        "repositoryURL": "https://github.com/apple/swift-service-context.git",
+        "state": {
+          "branch": null,
+          "revision": "ce0141c8f123132dbd02fd45fea448018762df1b",
+          "version": "1.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/LiveUI/XMLCoding.git", from: "0.4.1"),
-        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.18.0"),
+        .package(url: "https://github.com/amzn/smoke-http.git", from: "2.21.0"),
     ],
     targets: [
         .target(

--- a/Sources/AWSHttp/AWSClientProtocol+asyncSupport.swift
+++ b/Sources/AWSHttp/AWSClientProtocol+asyncSupport.swift
@@ -56,8 +56,7 @@ public extension AWSClientProtocol {
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
         } catch {
-            let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
-            throw typedError
+            try error.unwrapHTTPClientError(type: errorType)
         }
     }
     
@@ -92,8 +91,7 @@ public extension AWSClientProtocol {
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
         } catch {
-            let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
-            throw typedError
+            try error.unwrapHTTPClientError(type: errorType)
         }
     }
 }

--- a/Sources/AWSHttp/AWSClientProtocol+asyncSupport.swift
+++ b/Sources/AWSHttp/AWSClientProtocol+asyncSupport.swift
@@ -56,7 +56,7 @@ public extension AWSClientProtocol {
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
         } catch {
-            let typedError: ErrorType = error.asTypedError()
+            let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
             throw typedError
         }
     }
@@ -92,7 +92,7 @@ public extension AWSClientProtocol {
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
         } catch {
-            let typedError: ErrorType = error.asTypedError()
+            let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
             throw typedError
         }
     }

--- a/Sources/AWSHttp/AWSClientProtocol.swift
+++ b/Sources/AWSHttp/AWSClientProtocol.swift
@@ -48,8 +48,7 @@ public extension AWSClientProtocol {
             invocationContext: invocationContext,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnErrorProvider) .flatMapErrorThrowing { error in
-                let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
-                throw typedError
+                try error.unwrapHTTPClientError(type: errorType)
             }
     }
     
@@ -82,8 +81,7 @@ public extension AWSClientProtocol {
             invocationContext: invocationContext,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnErrorProvider) .flatMapErrorThrowing { error in
-                let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
-                throw typedError
+                try error.unwrapHTTPClientError(type: errorType)
             }
     }
 }

--- a/Sources/AWSHttp/AWSClientProtocol.swift
+++ b/Sources/AWSHttp/AWSClientProtocol.swift
@@ -48,7 +48,7 @@ public extension AWSClientProtocol {
             invocationContext: invocationContext,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnErrorProvider) .flatMapErrorThrowing { error in
-                let typedError: ErrorType = error.asTypedError()
+                let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
                 throw typedError
             }
     }
@@ -82,7 +82,7 @@ public extension AWSClientProtocol {
             invocationContext: invocationContext,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnErrorProvider) .flatMapErrorThrowing { error in
-                let typedError: ErrorType = error.asTypedError()
+                let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
                 throw typedError
             }
     }

--- a/Sources/AWSHttp/AWSQueryClientProtocol+asyncSupport.swift
+++ b/Sources/AWSHttp/AWSQueryClientProtocol+asyncSupport.swift
@@ -73,7 +73,7 @@ public extension AWSQueryClientProtocol {
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
         } catch {
-            let typedError: ErrorType = error.asTypedError()
+            let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
             throw typedError
         }
     }
@@ -108,7 +108,7 @@ public extension AWSQueryClientProtocol {
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
         } catch {
-            let typedError: ErrorType = error.asTypedError()
+            let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
             throw typedError
         }
     }

--- a/Sources/AWSHttp/AWSQueryClientProtocol+asyncSupport.swift
+++ b/Sources/AWSHttp/AWSQueryClientProtocol+asyncSupport.swift
@@ -73,8 +73,7 @@ public extension AWSQueryClientProtocol {
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
         } catch {
-            let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
-            throw typedError
+            try error.unwrapHTTPClientError(type: errorType)
         }
     }
       
@@ -108,8 +107,7 @@ public extension AWSQueryClientProtocol {
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnErrorProvider)
         } catch {
-            let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
-            throw typedError
+            try error.unwrapHTTPClientError(type: errorType)
         }
     }
 }

--- a/Sources/AWSHttp/AWSQueryClientProtocol.swift
+++ b/Sources/AWSHttp/AWSQueryClientProtocol.swift
@@ -45,8 +45,7 @@ public extension AWSQueryClientProtocol {
             invocationContext: invocationContext,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnErrorProvider) .flatMapErrorThrowing { error in
-                let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
-                throw typedError
+                try error.unwrapHTTPClientError(type: errorType)
             }
     }
         
@@ -78,8 +77,7 @@ public extension AWSQueryClientProtocol {
             invocationContext: invocationContext,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnErrorProvider) .flatMapErrorThrowing { error in
-                let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
-                throw typedError
+                try error.unwrapHTTPClientError(type: errorType)
             }
     }
 }

--- a/Sources/AWSHttp/AWSQueryClientProtocol.swift
+++ b/Sources/AWSHttp/AWSQueryClientProtocol.swift
@@ -45,7 +45,7 @@ public extension AWSQueryClientProtocol {
             invocationContext: invocationContext,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnErrorProvider) .flatMapErrorThrowing { error in
-                let typedError: ErrorType = error.asTypedError()
+                let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
                 throw typedError
             }
     }
@@ -78,7 +78,7 @@ public extension AWSQueryClientProtocol {
             invocationContext: invocationContext,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnErrorProvider) .flatMapErrorThrowing { error in
-                let typedError: ErrorType = error.asTypedError()
+                let typedError: ErrorType = try error.asTypedErrorThrowingHTTPErrors()
                 throw typedError
             }
     }

--- a/Sources/AWSHttp/ConvertableError.swift
+++ b/Sources/AWSHttp/ConvertableError.swift
@@ -29,17 +29,6 @@ public extension SmokeHTTPClient.HTTPClientError {
             return ErrorType.asUnrecognizedError(error: cause)
         }
     }
-    
-    func asTypedErrorThrowingHTTPErrors<ErrorType: ConvertableError>() throws -> ErrorType {
-        if let typedError = cause as? ErrorType {
-            return typedError
-        } else if let httpError = cause as? HTTPError {
-            // throw the http error unwrapped
-            throw httpError
-        } else {
-            return ErrorType.asUnrecognizedError(error: cause)
-        }
-    }
 }
 
 public extension Swift.Error {
@@ -51,11 +40,11 @@ public extension Swift.Error {
         }
     }
     
-    func asTypedErrorThrowingHTTPErrors<ErrorType: ConvertableError>() throws -> ErrorType {
-        if let typedError = self as? SmokeHTTPClient.HTTPClientError {
-            return try typedError.asTypedErrorThrowingHTTPErrors()
+    func unwrapHTTPClientError<ErrorType: ConvertableError>(type: ErrorType.Type) throws -> Never {
+        if let typedError = self as? SmokeHTTPClient.HTTPClientError {            
+            throw typedError.cause
         } else {
-            return ErrorType.asUnrecognizedError(error: self)
+            throw self
         }
     }
 }

--- a/Sources/AWSHttp/ConvertableError.swift
+++ b/Sources/AWSHttp/ConvertableError.swift
@@ -29,12 +29,31 @@ public extension SmokeHTTPClient.HTTPClientError {
             return ErrorType.asUnrecognizedError(error: cause)
         }
     }
+    
+    func asTypedErrorThrowingHTTPErrors<ErrorType: ConvertableError>() throws -> ErrorType {
+        if let typedError = cause as? ErrorType {
+            return typedError
+        } else if let httpError = cause as? HTTPError {
+            // throw the http error unwrapped
+            throw httpError
+        } else {
+            return ErrorType.asUnrecognizedError(error: cause)
+        }
+    }
 }
 
 public extension Swift.Error {
     func asTypedError<ErrorType: ConvertableError>() -> ErrorType {
         if let typedError = self as? SmokeHTTPClient.HTTPClientError {
             return typedError.asTypedError()
+        } else {
+            return ErrorType.asUnrecognizedError(error: self)
+        }
+    }
+    
+    func asTypedErrorThrowingHTTPErrors<ErrorType: ConvertableError>() throws -> ErrorType {
+        if let typedError = self as? SmokeHTTPClient.HTTPClientError {
+            return try typedError.asTypedErrorThrowingHTTPErrors()
         } else {
             return ErrorType.asUnrecognizedError(error: self)
         }

--- a/Sources/AWSHttp/HTTPClientDelegate+getErrorFromResponseAndBody.swift
+++ b/Sources/AWSHttp/HTTPClientDelegate+getErrorFromResponseAndBody.swift
@@ -40,6 +40,10 @@ extension HTTPClientDelegate {
                      metadata: ["body": "\(bodyWithErrorTypeAsJSON.debugString)"])
         
         // attempt to get an error of Error type by decoding the body data
-        return try JSONDecoder.awsCompatibleDecoder().decode(ErrorType.self, from: bodyWithErrorTypeAsJSON)
+        do {
+            return try JSONDecoder.awsCompatibleDecoder().decode(ErrorType.self, from: bodyWithErrorTypeAsJSON)
+        } catch let error as DecodingError {
+            throw HTTPError.deserializationError(cause: error)
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Just unwrap the HTTPServerError when possible (ie. with throwing functions). This makes it easier to identify the underlying reason for these errors (such as HTTPError.unauthorized, validationErrors for example) rather than the error being wrapped in a ServiceErrorType.UnrecognizedError.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
