### PR TITLE
Add CredentialsProviderV2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ jobs:
   run-codeql-linux:
     name: Run CodeQL on Linux
     runs-on: ubuntu-latest
+    container: swift:5.8
     permissions:
       security-events: write
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        swift: ["5.8"]
+        swift: ["5.9"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.23.0
+      - uses: swift-actions/setup-swift@v1.25.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -26,10 +26,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.7.3", "5.6.3"]
+        swift: ["5.8.1", "5.7.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.23.0
+      - uses: swift-actions/setup-swift@v1.25.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-aws-support/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.6|5.7|5.8-orange.svg?style=flat" alt="Swift 5.6, 5.7 and 5.8 Tested">
+<img src="https://img.shields.io/badge/swift-5.7|5.8|5.9-orange.svg?style=flat" alt="Swift 5.7, 5.8 and 5.9 Tested">
 </a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">

--- a/Sources/AWSCore/CredentialsProvider.swift
+++ b/Sources/AWSCore/CredentialsProvider.swift
@@ -26,7 +26,7 @@ public protocol CredentialsProviderV2 {
      Returns the current credentials. The provider should ensure that the returned credentials are valid and
      refresh them if they are not.
      */
-    func getCredentials() async -> Credentials
+    func getCredentials() async throws -> Credentials
 }
 
 /**

--- a/Sources/AWSCore/CredentialsProvider.swift
+++ b/Sources/AWSCore/CredentialsProvider.swift
@@ -19,6 +19,18 @@ import Foundation
 
 /**
   Protocol for providing a Credentials instance for a request. Instances of this protocol
+  that are passed to an AWS Client are used throughout the lifetime of that client.
+ */
+public protocol CredentialsProviderV2 {
+    /**
+     Returns the current credentials. The provider should ensure that the returned credentials are valid and
+     refresh them if they are not.
+     */
+    func getCredentials() async -> Credentials
+}
+
+/**
+  Protocol for providing a Credentials instance for a request. Instances of this protocol
   that are passed to an AWS Client are used throughout the lifetime of that client. Each
   request retrieves a new Credentials instance that is used for that request. For credential
   rotation, the CredentialProvider implementation should manage swapping out an immutable

--- a/Sources/AWSHttp/AWSClientProtocol+asyncSupport.swift
+++ b/Sources/AWSHttp/AWSClientProtocol+asyncSupport.swift
@@ -35,13 +35,26 @@ public extension AWSClientProtocol {
             reporting: InvocationReportingType,
             signAllHeaders: Bool = false,
             errorType: ErrorType.Type) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
-                    credentialsProvider: credentialsProvider,
-                    awsRegion: awsRegion,
-                    service: service,
-                    operation: operation,
-                    target: target,
-                    signAllHeaders: signAllHeaders)
+        let handlerDelegate: AWSClientInvocationDelegate
+        if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
+            let credentials = await credentialsProviderV2.getCredentials()
+            
+            handlerDelegate = AWSClientInvocationDelegate(
+                credentials: credentials,
+                awsRegion: awsRegion,
+                service: service,
+                operation: operation,
+                target: target,
+                signAllHeaders: signAllHeaders)
+        } else {
+            handlerDelegate = AWSClientInvocationDelegate(
+                credentialsProvider: credentialsProvider,
+                awsRegion: awsRegion,
+                service: service,
+                operation: operation,
+                target: target,
+                signAllHeaders: signAllHeaders)
+        }
 
         let invocationContext = HTTPClientInvocationContext(reporting: reporting,
                                                             handlerDelegate: handlerDelegate)
@@ -71,13 +84,26 @@ public extension AWSClientProtocol {
             reporting: InvocationReportingType,
             signAllHeaders: Bool = false,
             errorType: ErrorType.Type) async throws -> OutputType {
-        let handlerDelegate = AWSClientInvocationDelegate(
-                    credentialsProvider: credentialsProvider,
-                    awsRegion: awsRegion,
-                    service: service,
-                    operation: operation,
-                    target: target,
-                    signAllHeaders: signAllHeaders)
+        let handlerDelegate: AWSClientInvocationDelegate
+        if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
+            let credentials = await credentialsProviderV2.getCredentials()
+            
+            handlerDelegate = AWSClientInvocationDelegate(
+                credentials: credentials,
+                awsRegion: awsRegion,
+                service: service,
+                operation: operation,
+                target: target,
+                signAllHeaders: signAllHeaders)
+        } else {
+            handlerDelegate = AWSClientInvocationDelegate(
+                credentialsProvider: credentialsProvider,
+                awsRegion: awsRegion,
+                service: service,
+                operation: operation,
+                target: target,
+                signAllHeaders: signAllHeaders)
+        }
 
         let invocationContext = HTTPClientInvocationContext(reporting: reporting,
                                                             handlerDelegate: handlerDelegate)

--- a/Sources/AWSHttp/AWSClientProtocol+asyncSupport.swift
+++ b/Sources/AWSHttp/AWSClientProtocol+asyncSupport.swift
@@ -37,7 +37,7 @@ public extension AWSClientProtocol {
             errorType: ErrorType.Type) async throws {
         let handlerDelegate: AWSClientInvocationDelegate
         if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
-            let credentials = await credentialsProviderV2.getCredentials()
+            let credentials = try await credentialsProviderV2.getCredentials()
             
             handlerDelegate = AWSClientInvocationDelegate(
                 credentials: credentials,
@@ -86,7 +86,7 @@ public extension AWSClientProtocol {
             errorType: ErrorType.Type) async throws -> OutputType {
         let handlerDelegate: AWSClientInvocationDelegate
         if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
-            let credentials = await credentialsProviderV2.getCredentials()
+            let credentials = try await credentialsProviderV2.getCredentials()
             
             handlerDelegate = AWSClientInvocationDelegate(
                 credentials: credentials,

--- a/Sources/AWSHttp/AWSQueryClientProtocol+asyncSupport.swift
+++ b/Sources/AWSHttp/AWSQueryClientProtocol+asyncSupport.swift
@@ -50,11 +50,22 @@ public extension AWSQueryClientProtocol {
             action: String,
             reporting: InvocationReportingType,
             errorType: ErrorType.Type) async throws {
-        let handlerDelegate = AWSClientInvocationDelegate(
-                    credentialsProvider: credentialsProvider,
-                    awsRegion: awsRegion,
-                    service: service,
-                    target: target)
+        let handlerDelegate: AWSClientInvocationDelegate
+        if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
+            let credentials = await credentialsProviderV2.getCredentials()
+            
+            handlerDelegate = AWSClientInvocationDelegate(
+                credentials: credentials,
+                awsRegion: awsRegion,
+                service: service,
+                target: target)
+        } else {
+            handlerDelegate = AWSClientInvocationDelegate(
+                credentialsProvider: credentialsProvider,
+                awsRegion: awsRegion,
+                service: service,
+                target: target)
+        }
         
         let invocationContext = HTTPClientInvocationContext(reporting: reporting,
                                                             handlerDelegate: handlerDelegate)
@@ -86,11 +97,22 @@ public extension AWSQueryClientProtocol {
             action: String,
             reporting: InvocationReportingType,
             errorType: ErrorType.Type) async throws -> OutputType {
-        let handlerDelegate = AWSClientInvocationDelegate(
-                    credentialsProvider: credentialsProvider,
-                    awsRegion: awsRegion,
-                    service: service,
-                    target: target)
+        let handlerDelegate: AWSClientInvocationDelegate
+        if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
+            let credentials = await credentialsProviderV2.getCredentials()
+            
+            handlerDelegate = AWSClientInvocationDelegate(
+                credentials: credentials,
+                awsRegion: awsRegion,
+                service: service,
+                target: target)
+        } else {
+            handlerDelegate = AWSClientInvocationDelegate(
+                credentialsProvider: credentialsProvider,
+                awsRegion: awsRegion,
+                service: service,
+                target: target)
+        }
         
         let invocationContext = HTTPClientInvocationContext(reporting: reporting,
                                                             handlerDelegate: handlerDelegate)

--- a/Sources/AWSHttp/AWSQueryClientProtocol+asyncSupport.swift
+++ b/Sources/AWSHttp/AWSQueryClientProtocol+asyncSupport.swift
@@ -52,7 +52,7 @@ public extension AWSQueryClientProtocol {
             errorType: ErrorType.Type) async throws {
         let handlerDelegate: AWSClientInvocationDelegate
         if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
-            let credentials = await credentialsProviderV2.getCredentials()
+            let credentials = try await credentialsProviderV2.getCredentials()
             
             handlerDelegate = AWSClientInvocationDelegate(
                 credentials: credentials,
@@ -99,7 +99,7 @@ public extension AWSQueryClientProtocol {
             errorType: ErrorType.Type) async throws -> OutputType {
         let handlerDelegate: AWSClientInvocationDelegate
         if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
-            let credentials = await credentialsProviderV2.getCredentials()
+            let credentials = try await credentialsProviderV2.getCredentials()
             
             handlerDelegate = AWSClientInvocationDelegate(
                 credentials: credentials,


### PR DESCRIPTION
*Issue #, if available:*

Add `CredentialsProviderV2` to support on-demand credential refreshes. This is primarily motivated by the behaviour of the lambda runtime where the runtime may be frozen when a background refresh is suppose to happen.

If the `CredentialProvider` instance provided to a client also conforms to this new protocol, use the `getCredentials() async throws` function requirement of this protocol instead.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
