### PR TITLE
Provide a static convenience method for AWSClientInvocationDelegate

### DIFF
--- a/Sources/AWSHttp/AWSClientInvocationDelegate.swift
+++ b/Sources/AWSHttp/AWSClientInvocationDelegate.swift
@@ -47,6 +47,13 @@ public struct AWSClientInvocationDelegate : HTTPClientInvocationDelegate {
     let isV4SignRequest: Bool
     let signAllHeaders: Bool
     
+    /**
+     Convenience factory function that constructs an `AWSClientInvocationDelegate` instance according to the
+     `credentialsProvider` provided. If the `credentialsProvider` conforms to the `CredentialsProviderV2`
+     protocol credentials will be retrieved using that protocol - potentially suspending while refreshed credentials are retrieved.
+     Otherwise credentials will be retrieved using the `CredentialsProvider` protocol which has the potential to use
+     expired credentials in some circumstances.
+     */
     public static func get(credentialsProvider: CredentialsProvider,
                            awsRegion: AWSRegion,
                            service: String,

--- a/Sources/AWSHttp/AWSClientInvocationDelegate.swift
+++ b/Sources/AWSHttp/AWSClientInvocationDelegate.swift
@@ -47,6 +47,42 @@ public struct AWSClientInvocationDelegate : HTTPClientInvocationDelegate {
     let isV4SignRequest: Bool
     let signAllHeaders: Bool
     
+    public static func get(credentialsProvider: CredentialsProvider,
+                           awsRegion: AWSRegion,
+                           service: String,
+                           operation: String? = nil,
+                           target: String? = nil,
+                           isV4SignRequest: Bool = true,
+                           specifyContentHeadersForZeroLengthBody: Bool = true,
+                           signAllHeaders: Bool = false) async throws -> AWSClientInvocationDelegate {
+        let handlerDelegate: AWSClientInvocationDelegate
+        if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
+            let credentials = try await credentialsProviderV2.getCredentials()
+            
+            handlerDelegate = AWSClientInvocationDelegate(
+                credentials: credentials,
+                awsRegion: awsRegion,
+                service: service,
+                operation: operation,
+                target: target,
+                isV4SignRequest: isV4SignRequest,
+                specifyContentHeadersForZeroLengthBody: specifyContentHeadersForZeroLengthBody,
+                signAllHeaders: signAllHeaders)
+        } else {
+            handlerDelegate = AWSClientInvocationDelegate(
+                credentialsProvider: credentialsProvider,
+                awsRegion: awsRegion,
+                service: service,
+                operation: operation,
+                target: target,
+                isV4SignRequest: isV4SignRequest,
+                specifyContentHeadersForZeroLengthBody: specifyContentHeadersForZeroLengthBody,
+                signAllHeaders: signAllHeaders)
+        }
+        
+        return handlerDelegate
+    }
+    
     public init (credentials: Credentials,
                  awsRegion: AWSRegion,
                  service: String,

--- a/Sources/AWSHttp/AWSClientProtocol+asyncSupport.swift
+++ b/Sources/AWSHttp/AWSClientProtocol+asyncSupport.swift
@@ -35,26 +35,13 @@ public extension AWSClientProtocol {
             reporting: InvocationReportingType,
             signAllHeaders: Bool = false,
             errorType: ErrorType.Type) async throws {
-        let handlerDelegate: AWSClientInvocationDelegate
-        if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
-            let credentials = try await credentialsProviderV2.getCredentials()
-            
-            handlerDelegate = AWSClientInvocationDelegate(
-                credentials: credentials,
-                awsRegion: awsRegion,
-                service: service,
-                operation: operation,
-                target: target,
-                signAllHeaders: signAllHeaders)
-        } else {
-            handlerDelegate = AWSClientInvocationDelegate(
-                credentialsProvider: credentialsProvider,
-                awsRegion: awsRegion,
-                service: service,
-                operation: operation,
-                target: target,
-                signAllHeaders: signAllHeaders)
-        }
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
+            credentialsProvider: credentialsProvider,
+            awsRegion: awsRegion,
+            service: service,
+            operation: operation,
+            target: target,
+            signAllHeaders: signAllHeaders)
 
         let invocationContext = HTTPClientInvocationContext(reporting: reporting,
                                                             handlerDelegate: handlerDelegate)
@@ -84,26 +71,13 @@ public extension AWSClientProtocol {
             reporting: InvocationReportingType,
             signAllHeaders: Bool = false,
             errorType: ErrorType.Type) async throws -> OutputType {
-        let handlerDelegate: AWSClientInvocationDelegate
-        if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
-            let credentials = try await credentialsProviderV2.getCredentials()
-            
-            handlerDelegate = AWSClientInvocationDelegate(
-                credentials: credentials,
-                awsRegion: awsRegion,
-                service: service,
-                operation: operation,
-                target: target,
-                signAllHeaders: signAllHeaders)
-        } else {
-            handlerDelegate = AWSClientInvocationDelegate(
-                credentialsProvider: credentialsProvider,
-                awsRegion: awsRegion,
-                service: service,
-                operation: operation,
-                target: target,
-                signAllHeaders: signAllHeaders)
-        }
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
+            credentialsProvider: credentialsProvider,
+            awsRegion: awsRegion,
+            service: service,
+            operation: operation,
+            target: target,
+            signAllHeaders: signAllHeaders)
 
         let invocationContext = HTTPClientInvocationContext(reporting: reporting,
                                                             handlerDelegate: handlerDelegate)

--- a/Sources/AWSHttp/AWSQueryClientProtocol+asyncSupport.swift
+++ b/Sources/AWSHttp/AWSQueryClientProtocol+asyncSupport.swift
@@ -50,22 +50,11 @@ public extension AWSQueryClientProtocol {
             action: String,
             reporting: InvocationReportingType,
             errorType: ErrorType.Type) async throws {
-        let handlerDelegate: AWSClientInvocationDelegate
-        if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
-            let credentials = try await credentialsProviderV2.getCredentials()
-            
-            handlerDelegate = AWSClientInvocationDelegate(
-                credentials: credentials,
-                awsRegion: awsRegion,
-                service: service,
-                target: target)
-        } else {
-            handlerDelegate = AWSClientInvocationDelegate(
-                credentialsProvider: credentialsProvider,
-                awsRegion: awsRegion,
-                service: service,
-                target: target)
-        }
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
+            credentialsProvider: credentialsProvider,
+            awsRegion: awsRegion,
+            service: service,
+            target: target)
         
         let invocationContext = HTTPClientInvocationContext(reporting: reporting,
                                                             handlerDelegate: handlerDelegate)
@@ -97,22 +86,11 @@ public extension AWSQueryClientProtocol {
             action: String,
             reporting: InvocationReportingType,
             errorType: ErrorType.Type) async throws -> OutputType {
-        let handlerDelegate: AWSClientInvocationDelegate
-        if let credentialsProviderV2 = credentialsProvider as? CredentialsProviderV2 {
-            let credentials = try await credentialsProviderV2.getCredentials()
-            
-            handlerDelegate = AWSClientInvocationDelegate(
-                credentials: credentials,
-                awsRegion: awsRegion,
-                service: service,
-                target: target)
-        } else {
-            handlerDelegate = AWSClientInvocationDelegate(
-                credentialsProvider: credentialsProvider,
-                awsRegion: awsRegion,
-                service: service,
-                target: target)
-        }
+        let handlerDelegate = try await AWSClientInvocationDelegate.get(
+            credentialsProvider: credentialsProvider,
+            awsRegion: awsRegion,
+            service: service,
+            target: target)
         
         let invocationContext = HTTPClientInvocationContext(reporting: reporting,
                                                             handlerDelegate: handlerDelegate)


### PR DESCRIPTION
*Issue #, if available:* This centralizes the logic for getting credentials (between `CredentialsProvider` and `CredentialsProviderV2`) for the `AWSClientInvocationDelegate` in a static method in that type. This will allow this logic to be more easily used externally such as in `smoke-aws`.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
